### PR TITLE
'View on github'-button to user page for non-projects

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,17 +20,18 @@
           <h1>{{ site.title | default: site.github.repository_name }}</h1>
           <h2>{{ site.description | default: site.github.project_tagline }}</h2>
         </header>
-
         <section id="downloads" class="clearfix">
           {% if site.show_downloads %}
           <a href="{{ site.github.zip_url }}" id="download-zip" class="button"><span>Download .zip</span></a>
           <a href="{{ site.github.tar_url }}" id="download-tar-gz" class="button"><span>Download .tar.gz</span></a>
           {% endif %}
+	  {% if site.github.is_project_page %}
           <a href="{{ site.github.repository_url }}" id="view-on-github" class="button"><span>View on GitHub</span></a>
-        </section>
-
+	  {% else %}
+          <a href="{{ site.github.owner_url }}" id="view-on-github" class="button"><span>View on GitHub</span></a>
+	  {% endif %}  
+        </section> 
         <hr>
-
         <section id="main_content">
           {{ content }}
         </section>


### PR DESCRIPTION
The 'View on github' button now points to the user page ('site.github.owner_url')
instead of the repository page ('site.github.repository_url') when the page
does not belong a project ('site.github.is_project_page' false).

Thus, the links now points to 'github/username' instead of ' github/username/username.github.io'.
