### PR TITLE
Allow for page-specific title and description

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,8 +17,8 @@
       <div class="inner">
 
         <header>
-          <h1>{{ site.title | default: site.github.repository_name }}</h1>
-          <h2>{{ site.description | default: site.github.project_tagline }}</h2>
+          <h1>{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
+          <h2>{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
         </header>
         <section id="downloads" class="clearfix">
           {% if site.show_downloads %}


### PR DESCRIPTION
Included page.title and page.description in default.html

This allows to set a page-specific title and description via
the YAML front matter in a markdown file. If not set, it defaults
to the currently used side-wide setting.