### PR TITLE
Let site title be used in header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,7 +19,7 @@
 
         <header>
           <h1>{{ site.title | default: page.title }}</h1>
-          <h2>{{ page.description | default: site.description | default: page.description }}</h2>
+          <h2>{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
         </header>
         <section id="downloads" class="clearfix">
           {% if site.show_downloads %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,8 +18,8 @@
       <div class="inner">
 
         <header>
-          <h1>{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
-          <h2>{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
+          <h1>{{ site.title | default: page.title }}</h1>
+          <h2>{{ page.description | default: site.description | default: page.description }}</h2>
         </header>
         <section id="downloads" class="clearfix">
           {% if site.show_downloads %}


### PR DESCRIPTION
Due to https://github.com/pages-themes/tactile/commit/5e8a1a89d0d58c52fa5e456cac8c3ad01988abae#diff-2c19d9859b055d0302043d0fa2833e3f, the page title will always be set, and the site title or repository title will never be used.

Allow `site.title` to be used first, if set, and fallback to `page.title` if not.