### PR TITLE
Fall back code font-family to monospace

### DIFF
--- a/_sass/jekyll-theme-tactile.scss
+++ b/_sass/jekyll-theme-tactile.scss
@@ -170,7 +170,7 @@ a.button span {
 
 code, pre {
   margin-bottom: 30px;
-  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
   font-size: 14px;
   color: #222;
 }


### PR DESCRIPTION
I'm actually missing all of the fonts listed for the `<code>` tag in my Ubuntu 20.10 and the Vivaldi browser (Chromium-based) by default ends up using well... base default serif font which doesn't look very pleasing for code. Firefox does a better job falling back to DejaVu Sans Mono. Anyway, not having to guess who has which font, I guess it's best to fall back to generic `monospace`.