### PR TITLE
Update Broken Link on Tactile Homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -98,7 +98,7 @@ end
 
 ### Large image
 
-![Branching](https://guides.github.com/activities/hello-world/branching.png)
+![Branching](https://docs.github.com/assets/cb-23923/images/help/repository/branching.png)
 
 
 ### Definition lists can be used with HTML syntax.


### PR DESCRIPTION
This commit fixes a broken link on the Tactile homepage by updating it with the correct source URL for the Large Image, ensuring a seamless user experience.