### PR TITLE
Fix footer background-image position bug

### DIFF
--- a/_sass/jekyll-theme-tactile.scss
+++ b/_sass/jekyll-theme-tactile.scss
@@ -319,7 +319,7 @@ footer {
   margin-top: 40px;
   font-size: 13px;
   color: #aaa;
-  background: transparent url('../images/hr.png') 0 0 no-repeat;
+  background: transparent url('../images/hr.png') 50% 0 no-repeat;
 }
 
 footer a {


### PR DESCRIPTION
To position the background image consistently with `<hr>` (See line 210 of same file.)

### Before
<img width="414" alt="footer-hr-before" src="https://github.com/user-attachments/assets/45378a63-7ed9-4515-9e38-41f63aebe06f" />

### After
<img width="414" alt="footer-hr-after" src="https://github.com/user-attachments/assets/09ae515d-e94d-42b2-b583-cf869c9963e5" />
